### PR TITLE
EPMDJ-2411 Service Group - Aggregated Coverage

### DIFF
--- a/admin-part/src/main/kotlin/Plugin.kt
+++ b/admin-part/src/main/kotlin/Plugin.kt
@@ -255,7 +255,7 @@ class Test2CodeAdminPart(
         if (serviceGroup.isNotEmpty()) {
             val aggregatedMessage = aggregator(serviceGroup, agentId, summaryDto) ?: summaryDto
             sendToGroup(
-                destination = Routes.Summary,
+                destination = Routes.ServiceGroups.Summary(serviceGroup),
                 message = aggregatedMessage
             )
         }

--- a/api/src/jvmMain/kotlin/Routes.kt
+++ b/api/src/jvmMain/kotlin/Routes.kt
@@ -73,6 +73,9 @@ class Routes {
         object MethodsCoveredByTestType
     }
 
-    @Location("/summary")
-    object Summary
+    @Location("/service-groups")
+    class ServiceGroups {
+        @Location("/{groupId}/summary")
+        class Summary(val groupId: String)
+    }
 }

--- a/tests/src/test/kotlin/Stream.kt
+++ b/tests/src/test/kotlin/Stream.kt
@@ -307,7 +307,7 @@ class CoverageSocketStreams : PluginStreams() {
                                             } else
                                                 risks.send(Risks.serializer() parse content)
                                         }
-                                        is Routes.Summary -> {
+                                        is Routes.ServiceGroups.Summary -> {
                                             if (content.isEmpty() || content == "[]" || content == "\"\"") {
                                                 summary.send(null)
                                             } else summary.send(SummaryDto.serializer() parse content)


### PR DESCRIPTION
changed the route: from '/summary' to '/service-groups/{groupId}/summary'