### PR TITLE
EPMDJ-5659 Extend test report when integration tests are failed

### DIFF
--- a/tests/src/test/kotlin/e2e/CoverageByPackagesTest.kt
+++ b/tests/src/test/kotlin/e2e/CoverageByPackagesTest.kt
@@ -16,7 +16,7 @@ class CoverageByPackagesTest : E2EPluginTest() {
 
     @Test
     fun `cover one method in 2 scopes`() {
-        createSimpleAppWithPlugin<CoverageSocketStreams> {
+        createSimpleAppWithPlugin<CoverageSocketStreams>(timeout = 35L) {
             connectAgent<Build1> { plugUi, build ->
 
                 plugUi.coveragePackages()!!.first().apply {


### PR DESCRIPTION
added a log info for tests; increased timeout for the failed test
