### PR TITLE
EPMDJ-6900 Move classBytes of app to db instead of heap

### DIFF
--- a/admin-part/src/main/kotlin/ScopeHandler.kt
+++ b/admin-part/src/main/kotlin/ScopeHandler.kt
@@ -19,6 +19,7 @@ import com.epam.drill.plugin.api.end.*
 import com.epam.drill.plugins.test2code.api.*
 import com.epam.drill.plugins.test2code.api.routes.*
 import com.epam.drill.plugins.test2code.common.api.*
+import com.epam.drill.plugins.test2code.storage.*
 import com.epam.drill.plugins.test2code.util.*
 import com.epam.kodux.util.*
 
@@ -29,7 +30,7 @@ internal fun Plugin.initActiveScope(): Boolean = activeScope.init { sessionChang
     sessions?.let {
         val context = state.coverContext()
         val bundleCounters = trackTime("bundleCounters") {
-            sessions.calcBundleCounters(context, bundleByTestCache)
+            sessions.calcBundleCounters(context, storeClient.loadClassBytes(agentInfo.id), bundleByTestCache)
         }.also { logPoolStats() }
         val coverageInfoSet = trackTime("coverageInfoSet") {
             bundleCounters.calculateCoverageData(context, this)

--- a/admin-part/src/main/kotlin/coverage/Model.kt
+++ b/admin-part/src/main/kotlin/coverage/Model.kt
@@ -44,7 +44,6 @@ internal data class CoverContext(
     val methods: List<Method>,
     val methodChanges: DiffMethods = DiffMethods(),
     val probeIds: Map<String, Long> = emptyMap(),
-    val classBytes: Map<String, ByteArray> = emptyMap(),
     val build: CachedBuild,
     val parentBuild: CachedBuild? = null,
     val testsToRun: GroupedTests = emptyMap(),

--- a/admin-part/src/test/kotlin/JsCoverageTest.kt
+++ b/admin-part/src/test/kotlin/JsCoverageTest.kt
@@ -62,7 +62,7 @@ class JsCoverageTest {
         }
         val finished = active.finish(enabled = true)
         val context = state.coverContext()
-        val bundleCounters = finished.calcBundleCounters(context)
+        val bundleCounters = finished.calcBundleCounters(context, emptyMap())
         val coverageData = bundleCounters.calculateCoverageData(context)
         coverageData.run {
             assertEquals(Count(3, 5), coverage.count)


### PR DESCRIPTION
removed classBytes from CoverContext, load them from db when it needs